### PR TITLE
Refactor scripts to achieve higher quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The [index](http://jiahaog.com/nativefier-icons/) is automatically generated wit
 Feel free to submit a pull request for any `.ico`, `.icns` or `.png` icon!
 
 - `.ico` - For Windows
-- `.icns` - For OSX
+- `.icns` - For macOS (Apple Icon Image format)
 - `.png` - For Linux
 
 If the icons for the correct platforms are found here, the [optional dependencies](https://github.com/jiahaog/nativefier/#optional-dependencies) for Nativefier might not be required to infer an icon for that particular target web page.
@@ -61,7 +61,7 @@ You're done! Submit a pull request with the changes and I'll merge them in as so
 
 The main [`./addIcon`](addIcon) script is also provided which takes an input `.png` or `.svg` and does steps 1 and 2 automatically for you.
  
-This script only runs on OSX with XCode installed as [IconUtil](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html) is required for conversion to a `.icns` file.
+This script only runs on OSX with XCode installed as [iconutil](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html) is required for conversion to a `.icns` file.
 
 Other helpful scripts are:
 
@@ -70,14 +70,15 @@ Other helpful scripts are:
 - [`./bin/convertToPng`](bin/convertToPng) (Supported on Linux)
 
 You need the following dependencies:
-- [ImageMagick](http://www.imagemagick.org/script/index.php) with `convert` and `identify` in your `$PATH`
-- [svg2png](https://github.com/domenic/svg2png) (For `addIcon` only)
-- [iconUtil](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html): Xcode needs to be installed (For `addIcon` and `convertToIcns` only)
+
+- [ImageMagick](http://www.imagemagick.org/script/index.php) with `convert` and `identify` in your `$PATH` (required for `.png` input)
+- [CairoSVG](https://cairosvg.org) (required for `.svg` input)
+- [iconutil](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html): Xcode needs to be installed (required to generate `.icns`)
 
 ## Work In Progress
 
 - [ ] CI tests for pull requests
-- [ ] Just use a `.png` and let CI convert the icons to the other formats
+- [ ] Just use a `.png` or `.svg` and let CI convert the icons to the other formats
 
 ## Credits
 

--- a/addIcon
+++ b/addIcon
@@ -3,71 +3,70 @@
 # Will automatically convert and add the output properly to gitCloud
 
 # USAGE
-# ./addIcon <input png or svg>
+# =====
+# ./addIcon <input.svg or input.png>
+# Example:
+# ./addIcon ~/Desktop/icon.png
 
-# Example
-# ./addIcon ~/Desktop/facebook.png
-
-## Dependencies
-
-# imagemagick, svg2png
-
+# Exit the shell script on error immediately
 set -e
 
-# Exec Paths
+# Check for dependencies
+# imagemagick
 type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Convert executable"; exit 1; }
-type identify >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Identify executable"; exit 1; }
+# svg2png
 type svg2png >/dev/null 2>&1 || { echo >&2 "Cannot find required svg2png executable"; exit 1; }
+# iconutil
+type iconutil >/dev/null 2>&1 || { echo >&2 "Cannot find required iconutil executable"; exit 1; }
 
-CONVERT_TO_ICNS="${BASH_SOURCE%/*}/bin/convertToIcns"
+# Import scripts as variable
+CONVERT_TO_PNG="${BASH_SOURCE%/*}/bin/convertToPng"
 CONVERT_TO_ICO="${BASH_SOURCE%/*}/bin/convertToIco"
+CONVERT_TO_ICNS="${BASH_SOURCE%/*}/bin/convertToIcns"
 
-TEMP_DIR="convert_temp_hello"
-
-function cleanUp() {
-    rm -rf "${TEMP_DIR}"
-}
-
-trap cleanUp EXIT
-
-mkdir -p "${TEMP_DIR}"
-
+# Argument
 SOURCE=$1
 
+# Check argument
 if [ -z "${SOURCE}" ]; then
 	echo "No source image specified"
 	exit 1
 fi
 
-NAME=$(basename "${SOURCE}")
-EXT="${NAME##*.}"
-BASE="${NAME%.*}"
+# File variables
+SOURCE_NAME=$(basename "${SOURCE}")
+SOURCE_EXT="${SOURCE_NAME##*.}"
+SOURCE_BASE="${SOURCE_NAME%.*}"
 
-if [ "${EXT}" == "svg" ]; then
-    svg2png "${SOURCE}" "--output=${TEMP_DIR}/${BASE}.png" "--width=1024" "--height=1024"
-    SOURCE="${TEMP_DIR}/${BASE}.png"
+# Temp directory
+TEMP_DIR=".addIcon"
+mkdir -p "${TEMP_DIR}"
+
+# Cleanup
+function cleanUp() {
+	rm -rf "${TEMP_DIR}"
+}
+trap cleanUp EXIT
+
+# Check for file type
+if [ "${SOURCE_EXT}" == "svg" ] || [ "${SOURCE_EXT}" == "png" ]; then
+  ${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${SOURCE_BASE}.png"
+  ${CONVERT_TO_ICO} "${TEMP_DIR}/${SOURCE_BASE}.png" "${TEMP_DIR}/${SOURCE_BASE}.ico"
+  ${CONVERT_TO_ICNS} "${SOURCE}" "${TEMP_DIR}/${SOURCE_BASE}.icns"
+
+  # Force exit 0 for cp so that if files are identical the script will still proceed to overwrite
+  cp "${TEMP_DIR}/${SOURCE_BASE}.png" "files/${SOURCE_BASE}.png" || :
+  cp "${TEMP_DIR}/${SOURCE_BASE}.ico" "files/${SOURCE_BASE}.ico" || :
+  cp "${TEMP_DIR}/${SOURCE_BASE}.icns" "files/${SOURCE_BASE}.icns" || :
+  
+  ## append to .gitCloud.yml
+  echo "- name: ${SOURCE_BASE}" >> _data/gitCloud.yml
+  echo "  href: files/${SOURCE_BASE}.png" >> _data/gitCloud.yml
+  echo "- name: ${SOURCE_BASE}" >> _data/gitCloud.yml
+  echo "  href: files/${SOURCE_BASE}.ico" >> _data/gitCloud.yml
+  echo "- name: ${SOURCE_BASE}" >> _data/gitCloud.yml
+  echo "  href: files/${SOURCE_BASE}.icns" >> _data/gitCloud.yml
+else
+	echo "SVG or PNG must be provided"
+	exit 1
 fi
-
-NAME=$(basename "${SOURCE}")
-EXT="${NAME##*.}"
-
-if [ "${EXT}" != "png" ]; then
-    echo ".png or .svg must be provided"
-    exit 1
-fi
-
-# Force exit 0 for cp so that if files are identical the script will still proceed to overwrite
-cp "${SOURCE}" "files/${BASE}.png" || :
-${CONVERT_TO_ICNS} "${SOURCE}" "files/${BASE}.icns"
-${CONVERT_TO_ICO} "${SOURCE}" "files/${BASE}.ico"
-
-## append to .gitCloud.yml
-echo "- name: ${BASE}" >> _data/gitCloud.yml
-echo "  href: files/${BASE}.png" >> _data/gitCloud.yml
-echo "- name: ${BASE}" >> _data/gitCloud.yml
-echo "  href: files/${BASE}.ico" >> _data/gitCloud.yml
-echo "- name: ${BASE}" >> _data/gitCloud.yml
-echo "  href: files/${BASE}.icns" >> _data/gitCloud.yml
-
-trap - EXIT
-cleanUp

--- a/bin/convertToIcns
+++ b/bin/convertToIcns
@@ -1,25 +1,26 @@
 #!/bin/sh
 
-### USAGE
+# USAGE
+# =====
+# ./convertToIcns <input.svg or input.png> <output.icns>
+# Example:
+# ./convertToIcns ~/icon.png ~/Desktop/icon_converted.icns
 
-# ./convertToIcns <input png> <outp icns>
-# Example
-# ./convertToIcns ~/sample.png ~/Desktop/converted.icns
-
-# exit the shell script on error immediately
+# Exit the shell script on error immediately
 set -e
 
-# import script as variable
-CONVERT_TO_PNG="${BASH_SOURCE%/*}/convertToPng"
-
-type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Convert executable"; exit 1; }
+# Check for dependency
+# iconutil
 type iconutil >/dev/null 2>&1 || { echo >&2 "Cannot find required iconutil executable"; exit 1; }
 
-# Parameters
+# Import script as variable
+CONVERT_TO_PNG="${BASH_SOURCE%/*}/convertToPng"
+
+# Arguments
 SOURCE=$1
 DEST=$2
 
-# Check source and destination arguments
+# Check arguments
 if [ -z "${SOURCE}" ]; then
 	echo "No source image specified"
 	exit 1
@@ -30,40 +31,38 @@ if [ -z "${DEST}" ]; then
 	exit 1
 fi
 
-# File Infrastructure
-NAME=$(basename "${SOURCE}")
-EXT="${NAME##*.}"
-BASE="${NAME%.*}"
-TEMP_DIR="temp_icon"
-ICONSET="${BASE}.iconset"
+# File variables
+SOURCE_NAME=$(basename "${SOURCE}")
+SOURCE_EXT="${SOURCE_NAME##*.}"
+SOURCE_BASE="${SOURCE_NAME%.*}"
+ICONSET="${SOURCE_BASE}.iconset"
 
+# Temp directory
+TEMP_DIR=".convertToIcns"
+mkdir -p "${TEMP_DIR}/${ICONSET}"
+
+# Cleanup
 function cleanUp() {
-    rm -rf "${TEMP_DIR}"
-    rm -rf "${ICONSET}"
+	rm -rf "${TEMP_DIR}"
 }
-
 trap cleanUp EXIT
 
-mkdir -p "${TEMP_DIR}"
-mkdir -p "${ICONSET}"
+# Check for file type
+if [ "${SOURCE_EXT}" == "svg" ] || [ "${SOURCE_EXT}" == "png" ]; then
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_16x16.png" 16
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_16x16@2x.png" 32
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_32x32.png" 32
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_32x32@2x.png" 64
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_128x128.png" 128
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_128x128@2x.png" 256
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_256x256.png" 256
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_256x256@2x.png" 512
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_512x512.png" 512
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${ICONSET}/icon_512x512@2x.png" 1024
+else
+	echo "SVG or PNG must be provided"
+	exit 1
+fi
 
-PNG_PATH="${TEMP_DIR}/icon.png"
-${CONVERT_TO_PNG} "${SOURCE}" "${PNG_PATH}"
-
-# Resample image into iconset
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 16x16 "${ICONSET}/icon_16x16.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 32x32 "${ICONSET}/icon_16x16@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 32x32 "${ICONSET}/icon_32x32.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 64x64 "${ICONSET}/icon_32x32@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 128x128 "${ICONSET}/icon_128x128.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 256x256 "${ICONSET}/icon_128x128@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 256x256 "${ICONSET}/icon_256x256.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 512x512 "${ICONSET}/icon_256x256@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 512x512 "${ICONSET}/icon_512x512.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 1024x1024 "${ICONSET}/icon_512x512@2x.png"
-
-# Create an icns file lefrom the iconset
-iconutil -c icns "${ICONSET}" -o "${DEST}"
-
-trap - EXIT
-cleanUp
+# Create an icns file from the iconset
+iconutil -c icns "${TEMP_DIR}/${ICONSET}" -o "${DEST}"

--- a/bin/convertToIco
+++ b/bin/convertToIco
@@ -1,18 +1,27 @@
 #!/bin/sh
 
 # USAGE
+# =====
+# ./convertToIco <input.svg or input.png or input.ico> <output.ico> <square edge size (optional, defaults to 256 px)>
+# Example:
+# ./convertToIco ~/icon.png ~/Desktop/icon_converted.ico 16
 
-# ./convertToIco <input png or ico> <outfilename>.ico
-# Example
-# ./convertToPng ~/sample.png ~/converted.ico
-
+# Exit the shell script on error immediately
 set -e
 
+# Check for dependency
+# imagemagick
 type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Convert executable"; exit 1; }
 
+# Import script as variable
+CONVERT_TO_PNG="${BASH_SOURCE%/*}/convertToPng"
+
+# Arguments
 SOURCE=$1
 DEST=$2
+SIZE=$3
 
+# Check arguments
 if [ -z "${SOURCE}" ]; then
 	echo "No source image specified"
 	exit 1
@@ -23,13 +32,34 @@ if [ -z "${DEST}" ]; then
 	exit 1
 fi
 
-NAME=$(basename "${SOURCE}")
-EXT="${NAME##*.}"
-BASE="${NAME%.*}"
-
-if [ "${EXT}" == "ico" ]; then
-    cp "${SOURCE}" "${DEST}"
-    exit 0
+if [ -z "${SIZE}" ]; then
+	# Set default size to 256 px
+	SIZE=256
 fi
 
-convert "${SOURCE}" -resize 256x256 "${DEST}"
+# File variables
+SOURCE_NAME=$(basename "${SOURCE}")
+SOURCE_EXT="${SOURCE_NAME##*.}"
+SOURCE_BASE="${SOURCE_NAME%.*}"
+
+# Temp directory
+TEMP_DIR=".convertToIco"
+mkdir -p "${TEMP_DIR}"
+
+# Cleanup
+function cleanUp() {
+	rm -rf "${TEMP_DIR}"
+}
+trap cleanUp EXIT
+
+# Check for file type
+if [ "${SOURCE_EXT}" == "ico" ]; then
+	cp "${SOURCE}" "${DEST}"
+	exit 0
+elif [ "${SOURCE_EXT}" == "svg" ] || [ "${SOURCE_EXT}" == "png" ]; then
+	${CONVERT_TO_PNG} "${SOURCE}" "${TEMP_DIR}/${SOURCE_BASE}.png" "${SIZE}"
+	convert "${TEMP_DIR}/${SOURCE_BASE}.png" "${DEST}"
+else
+	echo "SVG, PNG or ICO must be provided"
+	exit 1
+fi

--- a/bin/convertToPng
+++ b/bin/convertToPng
@@ -1,21 +1,30 @@
 #!/bin/sh
 
 # USAGE
+# =====
+# ./convertToPng <input.svg or input.png or input.ico> <output.png> <square edge size (optional, defaults to 1024 px)>
+# Example:
+# ./convertToPng ~/icon.png ~/Desktop/icon_converted.png 512
 
-# ./convertToPng <input png or ico> <outfilename>.png
-# Example
-# ./convertToPng ~/sample.ico ~/Desktop/converted.png
-
+# Exit the shell script on error immediately
 set -e
 
-type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Convert executable"; exit 1; }
-type identify >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Identify executable"; exit 1; }
+# Check for dependencies
+if [ "${SOURCE_EXT}" == "png" ]; then
+  # imagemagick
+  type identify >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Identify executable"; exit 1; }
+  type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Convert executable"; exit 1; }
+elif [ "${SOURCE_EXT}" == "svg" ]; then
+  # CairoSVG
+  type cairosvg >/dev/null 2>&1 || { echo >&2 "Cannot find required CairoSVG executable"; exit 1; }
+fi
 
-# Parameters
+# Arguments
 SOURCE=$1
 DEST=$2
+SIZE=$3
 
-# Check source and destination arguments
+# Check arguments
 if [ -z "${SOURCE}" ]; then
 	echo "No source image specified"
 	exit 1
@@ -26,33 +35,41 @@ if [ -z "${DEST}" ]; then
 	exit 1
 fi
 
-# File Infrastructure
-NAME=$(basename "${SOURCE}")
-EXT="${NAME##*.}"
-BASE="${NAME%.*}"
-TEMP_DIR="convert_temp"
-
-function cleanUp() {
-    rm -rf "${TEMP_DIR}"
-}
-
-trap cleanUp EXIT
-
-mkdir -p "${TEMP_DIR}"
-
-# check if .ico is a sequence
-# pipe into cat so no exit code is given for grep if no matches are found
-IS_ICO_SET="$(identify ${SOURCE} | grep -e "\w\.ico\[0" | cat )"
-
-convert "${SOURCE}" "${TEMP_DIR}/${BASE}.png"
-if [ "${IS_ICO_SET}" ]; then
-	# extract the largest(?) image from the set
-    cp "${TEMP_DIR}/${BASE}-0.png" "${DEST}"
-else
-    cp "${TEMP_DIR}/${BASE}.png" "${DEST}"
+if [ -z "${SIZE}" ]; then
+	# Set default size to 1024 px
+	SIZE=1024
 fi
 
-rm -rf "${TEMP_DIR}"
+# File variables
+SOURCE_NAME=$(basename "${SOURCE}")
+SOURCE_EXT="${SOURCE_NAME##*.}"
+SOURCE_BASE="${SOURCE_NAME%.*}"
 
-trap - EXIT
-cleanUp
+# Temp directory
+TEMP_DIR=".convertToPng"
+mkdir -p "${TEMP_DIR}"
+
+# Cleanup
+function cleanUp() {
+	rm -rf "${TEMP_DIR}"
+}
+trap cleanUp EXIT
+
+# Check for file type
+if [ "${SOURCE_EXT}" == "svg" ]; then
+	cairosvg "${SOURCE}"  "--output-width=${SIZE}" "--output-height=${SIZE}" "--output=${DEST}"
+elif [ "${SOURCE_EXT}" == "png" ] || [ "${SOURCE_EXT}" == "ico" ]; then
+	# Check if .ico is a sequence
+	# Pipe into cat so no exit code is given for grep if no matches are found
+	IS_ICO_SET="$(identify ${SOURCE} | grep -e "\w\.ico\[0" | cat )"
+	convert "${SOURCE}" -define png:big-depth=16 -define png:color-type=6 -sample "${SIZE}x${SIZE}" "${TEMP_DIR}/${SOURCE_BASE}.png"
+	if [ "${IS_ICO_SET}" ]; then
+		# Extract the largest (?) image from the set
+		cp "${TEMP_DIR}/${SOURCE_BASE}-0.png" "${DEST}"
+	else
+		cp "${TEMP_DIR}/${SOURCE_BASE}.png" "${DEST}"
+	fi
+else
+	echo "SVG, PNG or ICO must be provided"
+	exit 1
+fi


### PR DESCRIPTION
I tried to refactor the scripts in the way SVG is used to generate all the PNG sizes for `.icns` file. I also exchanged svg2png for CairoSVG, therefore achieving higher quality output:

<img width="417" alt="snimek obrazovky 2019-01-07 v 0 28 13" src="https://user-images.githubusercontent.com/11633481/50743065-73eb7480-1213-11e9-9330-06d5c708dff7.png">

_(old one for comparison is below)_

Hopefully working but I'd be happy if anyone else can try.